### PR TITLE
Enforce UTF-8 encoding on changelog file read

### DIFF
--- a/lib/semvergen/change_log_file.rb
+++ b/lib/semvergen/change_log_file.rb
@@ -7,7 +7,7 @@ module Semvergen
     end
 
     def <<(message)
-      current_change_log = File.exist?(@change_log_filename) ? File.read(@change_log_filename) : ""
+      current_change_log = File.exist?(@change_log_filename) ? File.read(@change_log_filename, :encoding => "UTF-8") : ""
       new_change_log     = "# Changelog\n\n#{message}" + current_change_log.gsub("# Changelog\n", "")
       File.open(@change_log_filename, "w") { |f| f.write new_change_log }
     end


### PR DESCRIPTION
To get around this error when there are ellipsis in the changelog:
`ArgumentError: invalid byte sequence in US-ASCII`