### PR TITLE
Extend gem to support optional node module bumping

### DIFF
--- a/lib/semvergen.rb
+++ b/lib/semvergen.rb
@@ -8,6 +8,8 @@ require "semvergen/change_log_file"
 require "semvergen/shell"
 require "semvergen/version_file"
 
+require "semvergen/extensions/node_module/version_file"
+
 require "yaml"
 
 module Semvergen

--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -16,7 +16,7 @@ module Semvergen
 
     def_delegators :@interface, :say, :ask, :color, :choose, :newline, :agree
 
-    def initialize(interface, version_file, change_log_file, shell, gem_name, gem_server, notifier)
+    def initialize(interface, version_file, change_log_file, shell, gem_name, gem_server, notifier, node_version_file=nil)
       @interface = interface
       @version_file = version_file
       @change_log_file = change_log_file
@@ -24,6 +24,8 @@ module Semvergen
       @gem_name = gem_name
       @gem_server = gem_server
       @notifier = notifier
+
+      @node_version_file = node_version_file
     end
 
     def run!(options)
@@ -124,6 +126,13 @@ module Semvergen
 
         if agree("Proceed? ")
           @version_file.version = new_version
+          if @node_version_file
+            @node_version_file.version = new_version
+            if @shell.publish_node_module.nil?
+              say color("NPM not found!", :underline, :red)
+              return
+            end
+          end
 
           @change_log_file << change_log_message
 

--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -16,7 +16,7 @@ module Semvergen
 
     def_delegators :@interface, :say, :ask, :color, :choose, :newline, :agree
 
-    def initialize(interface, version_file, node_version_file=nil, change_log_file, shell, gem_name, gem_server, notifier)
+    def initialize(interface, version_file, node_version_file, change_log_file, shell, gem_name, gem_server, notifier)
       @interface = interface
       @version_file = version_file
       @node_version_file = node_version_file

--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -16,16 +16,15 @@ module Semvergen
 
     def_delegators :@interface, :say, :ask, :color, :choose, :newline, :agree
 
-    def initialize(interface, version_file, change_log_file, shell, gem_name, gem_server, notifier, node_version_file=nil)
+    def initialize(interface, version_file, node_version_file=nil, change_log_file, shell, gem_name, gem_server, notifier)
       @interface = interface
       @version_file = version_file
+      @node_version_file = node_version_file
       @change_log_file = change_log_file
       @shell = shell
       @gem_name = gem_name
       @gem_server = gem_server
       @notifier = notifier
-
-      @node_version_file = node_version_file
     end
 
     def run!(options)
@@ -128,10 +127,6 @@ module Semvergen
           @version_file.version = new_version
           if @node_version_file
             @node_version_file.version = new_version
-            if @shell.publish_node_module.nil?
-              say color("NPM not found!", :underline, :red)
-              return
-            end
           end
 
           @change_log_file << change_log_message
@@ -146,6 +141,7 @@ module Semvergen
         Semvergen::Release.new(
           @interface,
           @version_file,
+          @node_version_file,
           @change_log_file,
           @shell,
           @gem_name,

--- a/lib/semvergen/extensions/node_module/version_file.rb
+++ b/lib/semvergen/extensions/node_module/version_file.rb
@@ -1,0 +1,29 @@
+module Semvergen
+  module Extensions
+    module NodeModule
+      class VersionFile
+
+        def initialize(file)
+          @file = file
+        end
+
+        def version=(new_version)
+          content = file.read.gsub(/"version".*$/, %Q["version": "#{new_version}",])
+          file.truncate(0)
+          file.write content
+          file.flush
+        end
+
+        def file
+          @file.rewind
+          @file
+        end
+
+        def path
+          @file.path
+        end
+
+      end
+    end
+  end
+end

--- a/lib/semvergen/launcher.rb
+++ b/lib/semvergen/launcher.rb
@@ -3,7 +3,7 @@ module Semvergen
   class Launcher
 
     def bump!(options={})
-      Semvergen::Bump.new(interface, version_file, change_log_file, shell, gem_name, gem_server, notifier).run!(options)
+      Semvergen::Bump.new(interface, version_file, change_log_file, shell, gem_name, gem_server, notifier, node_version_file).run!(options)
     end
 
     def release!(options={})
@@ -20,6 +20,16 @@ module Semvergen
       end
     end
 
+    def node_version_file
+      if config["node_module"]
+        if File.exist? node_version_path
+          Extensions::NodeModule::VersionFile.new(File.open(node_version_path, "r+"))
+        else
+          interface.fail_exit "A npm style version file should be found at #{node_version_path}"
+        end
+      end
+    end
+
     def change_log_file
       ChangeLogFile.new
     end
@@ -30,6 +40,10 @@ module Semvergen
 
     def version_path
       File.join("lib", gem_name, "version.rb")
+    end
+
+    def node_version_path
+      File.join("package.json")
     end
 
     def gem_name

--- a/lib/semvergen/release.rb
+++ b/lib/semvergen/release.rb
@@ -6,9 +6,10 @@ module Semvergen
 
     def_delegators :@interface, :say, :ask, :color, :choose, :newline, :agree
 
-    def initialize(interface, version_file, change_log_file, shell, gem_name, gem_server, notifier)
+    def initialize(interface, version_file, node_version_file=nil, change_log_file, shell, gem_name, gem_server, notifier)
       @interface = interface
       @version_file = version_file
+      @node_version_file = node_version_file
       @change_log_file = change_log_file
       @shell = shell
       @gem_name = gem_name
@@ -31,6 +32,13 @@ module Semvergen
         say color("Publishing: ")
         @shell.publish(@gem_name, @version_file.version, @gem_server)
         say color("OK", :green, :bold)
+
+        if @node_version_file
+          say color("Publishing to NPM: ")
+          if @shell.publish_node_module.nil?
+            say color("Error: npm CLI not found! Please ensure that 'npm publish' runs successfully", :underline, :red)
+          end
+        end
 
         features = options[:features] || gem_features
         @notifier.gem_published(@gem_name, gem_version, features.join("\n"))

--- a/lib/semvergen/release.rb
+++ b/lib/semvergen/release.rb
@@ -6,7 +6,7 @@ module Semvergen
 
     def_delegators :@interface, :say, :ask, :color, :choose, :newline, :agree
 
-    def initialize(interface, version_file, node_version_file=nil, change_log_file, shell, gem_name, gem_server, notifier)
+    def initialize(interface, version_file, node_version_file, change_log_file, shell, gem_name, gem_server, notifier)
       @interface = interface
       @version_file = version_file
       @node_version_file = node_version_file

--- a/lib/semvergen/shell.rb
+++ b/lib/semvergen/shell.rb
@@ -49,6 +49,9 @@ module Semvergen
       else
         publish_to_gemserver(gem_name, version, gem_server)
       end
+
+    def publish_node_module
+      execute "npm publish" rescue nil
     end
 
     def cleanup(gem_name, version)


### PR DESCRIPTION
Adds support for optional config parameter `node_module`.
If set to true, the version in package.json will be updated to the new release version and `npm publish` will be ran.

If `npm` is not available on CLI the script will emit an warning but not fail.