### PR TITLE
Stage package.json for commit if available

### DIFF
--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -125,13 +125,16 @@ module Semvergen
 
         if agree("Proceed? ")
           @version_file.version = new_version
+
+          node_version_file_path = nil
           if @node_version_file
             @node_version_file.version = new_version
+            node_version_file_path = @node_version_file.path
           end
 
           @change_log_file << change_log_message
 
-          @shell.commit(@version_file.path, new_version, commit_message, features)
+          @shell.commit(@version_file.path, node_version_file_path, new_version, commit_message, features)
 
           @shell.push(new_version)
 

--- a/lib/semvergen/shell.rb
+++ b/lib/semvergen/shell.rb
@@ -26,11 +26,14 @@ module Semvergen
       `git rev-list HEAD..@{u} --count`.strip.to_i == 0
     end
 
-    def commit(version_path, new_version, commit_subject, features)
+    def commit(version_path, node_version_path, new_version, commit_subject, features)
       commit_body = commit_message(new_version, commit_subject, features.join("\n"))
 
       execute "git add CHANGELOG.md"
       execute "git add #{version_path}"
+      if node_version_path
+        execute "git add #{node_version_path}"
+      end
       execute %Q[git commit -m "#{commit_body}"]
       execute %Q[git tag #{new_version} -a -m "Version: #{new_version} - #{commit_subject}"]
     end


### PR DESCRIPTION
The original implementation did not stage the updated package.json
This went under the radar, since I commented-out all git commands in order to test this while developing.