### PR TITLE
Add date to releases

### DIFF
--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -74,7 +74,7 @@ module Semvergen
         say "Enter change log features (or a blank line to finish):"
 
         features = []
-        features << "Release date: #{Time.now.to_s}"
+        features << "* Release date: #{Time.now.to_s}"
 
         while true
           response = ask "* " do |q|

--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -73,7 +73,8 @@ module Semvergen
 
         say "Enter change log features (or a blank line to finish):"
 
-        features = ["Release date: #{Time.now.to_s}"]
+        features = []
+        features << "Release date: #{Time.now.to_s}"
 
         while true
           response = ask "* " do |q|

--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -73,7 +73,7 @@ module Semvergen
 
         say "Enter change log features (or a blank line to finish):"
 
-        features = []
+        features = ["Release date: #{Time.now.to_s}"]
 
         while true
           response = ask "* " do |q|

--- a/lib/semvergen/bump.rb
+++ b/lib/semvergen/bump.rb
@@ -74,7 +74,6 @@ module Semvergen
         say "Enter change log features (or a blank line to finish):"
 
         features = []
-        features << "* Release date: #{Time.now.to_s}"
 
         while true
           response = ask "* " do |q|
@@ -92,7 +91,7 @@ module Semvergen
           end
         end
 
-        change_log_lines   = ["# #{new_version}"] + features
+        change_log_lines   = ["# #{new_version} - Release date: #{Time.now.strftime("%Y-%d-%m")}"] + features
         change_log_message = change_log_lines.join("\n")
         diff_change_log    = change_log_lines.map { |l| color("+++ ", :white) + color(l, :green) }.join("\n")
 


### PR DESCRIPTION
It's good to know when versions are released for debugging. Changelog messages and release messages will look like this:

```
Will add the following to CHANGELOG.md
+++ # 12.0.1
+++ Release date: 2017-08-07 12:52:58 +0200
+++ * Fooo Baaaar (#2653)
+++


Summary of actions:

Bumping version: 12.0.0 -> 12.0.1

Adding features to CHANGELOG.md:
+++ # 12.0.1
+++ Release date: 2017-08-07 12:52:58 +0200
+++ * Fooo Baaaar (#2653)
+++```